### PR TITLE
Cleanups and perf: swift 6, sync front/back frame pairs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -48,5 +48,8 @@ jobs:
     - name: Build demo for iOS simulator
       run: xcrun xcodebuild build -project DualCameraDemo/DualCameraDemo.xcodeproj -scheme DualCameraDemo -destination "generic/platform=iOS Simulator" -derivedDataPath "$RUNNER_TEMP/DualCameraKitDerivedData" CODE_SIGNING_ALLOWED=NO
 
-    - name: Run package tests on iOS simulator
-      run: xcrun xcodebuild test -workspace .swiftpm/xcode/package.xcworkspace -scheme DualCameraKit-Package -destination "${{ steps.simulator.outputs.destination }}" -derivedDataPath "$RUNNER_TEMP/DualCameraKitDerivedData" CODE_SIGNING_ALLOWED=NO
+    - name: Run library tests on iOS simulator
+      run: xcrun xcodebuild test -project DualCameraDemo/DualCameraDemo.xcodeproj -scheme DualCameraKitTests -destination "${{ steps.simulator.outputs.destination }}" -derivedDataPath "$RUNNER_TEMP/DualCameraKitDerivedData" CODE_SIGNING_ALLOWED=NO
+
+    - name: Run demo unit tests on iOS simulator
+      run: xcrun xcodebuild test -project DualCameraDemo/DualCameraDemo.xcodeproj -scheme DualCameraDemo -destination "${{ steps.simulator.outputs.destination }}" -only-testing:DualCameraDemoTests -derivedDataPath "$RUNNER_TEMP/DualCameraKitDerivedData" CODE_SIGNING_ALLOWED=NO

--- a/DualCameraDemo/DualCameraDemo.xcodeproj/project.pbxproj
+++ b/DualCameraDemo/DualCameraDemo.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		4F7E4C7F2D6D2B0A006F5609 /* DualCameraKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4F7E4C7E2D6D2B0A006F5609 /* DualCameraKit */; };
 		4F7E4C812D6D6E81006F5609 /* DualCameraKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4F7E4C802D6D6E81006F5609 /* DualCameraKitUI */; };
+		4FC0000A2E0000000000000A /* DualCameraKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4F7E4C7E2D6D2B0A006F5609 /* DualCameraKit */; };
+		4FC0000B2E0000000000000B /* DualCameraKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4F7E4C802D6D6E81006F5609 /* DualCameraKitUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +47,7 @@
 		4F4D659B2D66D02C00F40490 /* DualCameraDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DualCameraDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F4D65AB2D66D02F00F40490 /* DualCameraDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DualCameraDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F4D65B52D66D02F00F40490 /* DualCameraDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DualCameraDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4FC000012E00000000000001 /* DualCameraKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DualCameraKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -61,6 +64,16 @@
 		4F4D65B82D66D02F00F40490 /* DualCameraDemoUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = DualCameraDemoUITests;
+			sourceTree = "<group>";
+		};
+		4FC000022E00000000000002 /* DualCameraKitTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ../Tests/DualCameraKitTests;
+			sourceTree = "<group>";
+		};
+		4FC0000C2E0000000000000C /* Helpers */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ../Tests/Helpers;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -89,6 +102,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4FC000032E00000000000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4FC0000A2E0000000000000A /* DualCameraKit in Frameworks */,
+				4FC0000B2E0000000000000B /* DualCameraKitUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -97,6 +119,8 @@
 			children = (
 				4F4D659D2D66D02C00F40490 /* DualCameraDemo */,
 				4F4D65AE2D66D02F00F40490 /* DualCameraDemoTests */,
+				4FC000022E00000000000002 /* DualCameraKitTests */,
+				4FC0000C2E0000000000000C /* Helpers */,
 				4F4D65B82D66D02F00F40490 /* DualCameraDemoUITests */,
 				4F4D659C2D66D02C00F40490 /* Products */,
 			);
@@ -107,6 +131,7 @@
 			children = (
 				4F4D659B2D66D02C00F40490 /* DualCameraDemo.app */,
 				4F4D65AB2D66D02F00F40490 /* DualCameraDemoTests.xctest */,
+				4FC000012E00000000000001 /* DualCameraKitTests.xctest */,
 				4F4D65B52D66D02F00F40490 /* DualCameraDemoUITests.xctest */,
 			);
 			name = Products;
@@ -186,6 +211,31 @@
 			productReference = 4F4D65B52D66D02F00F40490 /* DualCameraDemoUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		4FC000062E00000000000006 /* DualCameraKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4FC000072E00000000000007 /* Build configuration list for PBXNativeTarget "DualCameraKitTests" */;
+			buildPhases = (
+				4FC000042E00000000000004 /* Sources */,
+				4FC000032E00000000000003 /* Frameworks */,
+				4FC000052E00000000000005 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				4FC000022E00000000000002 /* DualCameraKitTests */,
+				4FC0000C2E0000000000000C /* Helpers */,
+			);
+			name = DualCameraKitTests;
+			packageProductDependencies = (
+				4F7E4C7E2D6D2B0A006F5609 /* DualCameraKit */,
+				4F7E4C802D6D6E81006F5609 /* DualCameraKitUI */,
+			);
+			productName = DualCameraKitTests;
+			productReference = 4FC000012E00000000000001 /* DualCameraKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -206,6 +256,9 @@
 					4F4D65B42D66D02F00F40490 = {
 						CreatedOnToolsVersion = 16.2;
 						TestTargetID = 4F4D659A2D66D02C00F40490;
+					};
+					4FC000062E00000000000006 = {
+						CreatedOnToolsVersion = 16.2;
 					};
 				};
 			};
@@ -228,6 +281,7 @@
 			targets = (
 				4F4D659A2D66D02C00F40490 /* DualCameraDemo */,
 				4F4D65AA2D66D02F00F40490 /* DualCameraDemoTests */,
+				4FC000062E00000000000006 /* DualCameraKitTests */,
 				4F4D65B42D66D02F00F40490 /* DualCameraDemoUITests */,
 			);
 		};
@@ -255,6 +309,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4FC000052E00000000000005 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -273,6 +334,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4F4D65B12D66D02F00F40490 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FC000042E00000000000004 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -575,6 +643,46 @@
 			};
 			name = Release;
 		};
+		4FC000082E00000000000008 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dualcamerakit.DualCameraKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4FC000092E00000000000009 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dualcamerakit.DualCameraKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -610,6 +718,15 @@
 			buildConfigurations = (
 				4F4D65C62D66D02F00F40490 /* Debug */,
 				4F4D65C72D66D02F00F40490 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4FC000072E00000000000007 /* Build configuration list for PBXNativeTarget "DualCameraKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4FC000082E00000000000008 /* Debug */,
+				4FC000092E00000000000009 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DualCameraDemo/DualCameraDemo.xcodeproj/project.pbxproj
+++ b/DualCameraDemo/DualCameraDemo.xcodeproj/project.pbxproj
@@ -66,12 +66,12 @@
 			path = DualCameraDemoUITests;
 			sourceTree = "<group>";
 		};
-		4FC000022E00000000000002 /* DualCameraKitTests */ = {
+		4FC000022E00000000000002 /* ../Tests/DualCameraKitTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = ../Tests/DualCameraKitTests;
 			sourceTree = "<group>";
 		};
-		4FC0000C2E0000000000000C /* Helpers */ = {
+		4FC0000C2E0000000000000C /* ../Tests/Helpers */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = ../Tests/Helpers;
 			sourceTree = "<group>";
@@ -119,8 +119,8 @@
 			children = (
 				4F4D659D2D66D02C00F40490 /* DualCameraDemo */,
 				4F4D65AE2D66D02F00F40490 /* DualCameraDemoTests */,
-				4FC000022E00000000000002 /* DualCameraKitTests */,
-				4FC0000C2E0000000000000C /* Helpers */,
+				4FC000022E00000000000002 /* ../Tests/DualCameraKitTests */,
+				4FC0000C2E0000000000000C /* ../Tests/Helpers */,
 				4F4D65B82D66D02F00F40490 /* DualCameraDemoUITests */,
 				4F4D659C2D66D02C00F40490 /* Products */,
 			);
@@ -224,8 +224,8 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				4FC000022E00000000000002 /* DualCameraKitTests */,
-				4FC0000C2E0000000000000C /* Helpers */,
+				4FC000022E00000000000002 /* ../Tests/DualCameraKitTests */,
+				4FC0000C2E0000000000000C /* ../Tests/Helpers */,
 			);
 			name = DualCameraKitTests;
 			packageProductDependencies = (

--- a/DualCameraDemo/DualCameraDemo.xcodeproj/xcshareddata/xcschemes/DualCameraKitTests.xcscheme
+++ b/DualCameraDemo/DualCameraDemo.xcodeproj/xcshareddata/xcschemes/DualCameraKitTests.xcscheme
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4FC000062E00000000000006"
+               BuildableName = "DualCameraKitTests.xctest"
+               BlueprintName = "DualCameraKitTests"
+               ReferencedContainer = "container:DualCameraDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4FC000062E00000000000006"
+               BuildableName = "DualCameraKitTests.xctest"
+               BlueprintName = "DualCameraKitTests"
+               ReferencedContainer = "container:DualCameraDemo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
@@ -23,14 +23,14 @@ let package = Package(
                 .process("DualCameraShaders.metal")
             ],
             swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
+                .swiftLanguageMode(.v6)
             ]
         ),
         .target(
             name: "DualCameraKitUI",
             dependencies: ["DualCameraKit"],
             swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
+                .swiftLanguageMode(.v6)
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DualCameraKit
 
-![Swift](https://img.shields.io/badge/Swift-5.9-orange?logo=swift)
+![Swift](https://img.shields.io/badge/Swift-6-orange?logo=swift)
 ![SPM Compatible](https://img.shields.io/badge/SPM-Compatible-brightgreen)
 ![iOS](https://img.shields.io/badge/iOS-17+-lightgrey?logo=apple)
 ![Status](https://img.shields.io/badge/status-v0.5_photo_first-yellow)

--- a/Sources/DualCameraKit/CameraRenderer.swift
+++ b/Sources/DualCameraKit/CameraRenderer.swift
@@ -8,8 +8,18 @@ public protocol CameraRenderer: AnyObject {
     /// Backing UIKit view used by SwiftUI adapters.
     var view: UIView { get }
 
+    /// Controls how frames are scaled inside the renderer bounds.
+    var cameraContentMode: DualCameraContentMode { get set }
+
     /// Update renderer with new camera frame.
-    func update(with buffer: CVPixelBuffer)
+    nonisolated func update(with frame: PixelBufferWrapper)
+}
+
+public extension CameraRenderer {
+    /// Update renderer with a bare pixel buffer.
+    nonisolated func update(with buffer: CVPixelBuffer) {
+        update(with: PixelBufferWrapper(buffer: buffer))
+    }
 }
 
 enum MetalRendererError: Error {
@@ -31,7 +41,8 @@ public final class MetalCameraRenderer: MTKView, CameraRenderer, MTKViewDelegate
     private var commandQueue: MTLCommandQueue?
     private var textureCache: CVMetalTextureCache?
     private var renderPipelineState: MTLRenderPipelineState?
-    private var currentTexture: MTLTexture?
+    private let latestFrameStore = LatestPixelBufferStore()
+    public var cameraContentMode: DualCameraContentMode = .aspectFill
 
     // MARK: - Initialization
     public required init(coder: NSCoder) {
@@ -75,8 +86,8 @@ public final class MetalCameraRenderer: MTKView, CameraRenderer, MTKViewDelegate
 
         framebufferOnly = false
         preferredFramesPerSecond = UIScreen.main.maximumFramesPerSecond
-        isPaused = true
-        enableSetNeedsDisplay = true
+        isPaused = false
+        enableSetNeedsDisplay = false
         self.colorPixelFormat = .bgra8Unorm
 
         try setupRenderPipeline()
@@ -152,46 +163,8 @@ public final class MetalCameraRenderer: MTKView, CameraRenderer, MTKViewDelegate
 extension MetalCameraRenderer {
     public var view: UIView { self }
 
-    public func update(with buffer: CVPixelBuffer) {
-        let bufferWrapper = PixelBufferWrapper(buffer: buffer)
-        createAndUpdateTexture(from: bufferWrapper)
-    }
-
-    // MARK: - Private Helpers
-
-    /// Creates a texture from the given buffer and updates the view.
-    @MainActor
-    private func createAndUpdateTexture(from bufferWrapper: PixelBufferWrapper) {
-        guard let textureCache = self.textureCache else {
-            print("⚠️ No texture cache available")
-            return
-        }
-        let buffer = bufferWrapper.buffer
-        let width = CVPixelBufferGetWidth(buffer)
-        let height = CVPixelBufferGetHeight(buffer)
-
-        var textureRef: CVMetalTexture?
-        let status = CVMetalTextureCacheCreateTextureFromImage(
-            kCFAllocatorDefault,
-            textureCache,
-            buffer,
-            nil,
-            .bgra8Unorm,
-            width,
-            height,
-            0,
-            &textureRef
-        )
-
-        guard status == kCVReturnSuccess,
-              let textureRef = textureRef,
-              let metalTexture = CVMetalTextureGetTexture(textureRef) else {
-            print("❌ Failed to create texture: \(status)")
-            return
-        }
-
-        self.currentTexture = metalTexture
-        self.setNeedsDisplay()
+    public nonisolated func update(with frame: PixelBufferWrapper) {
+        latestFrameStore.store(frame)
     }
 }
 
@@ -214,8 +187,8 @@ extension MetalCameraRenderer {
 
         commandEncoder.setRenderPipelineState(pipelineState)
 
-        if let texture = currentTexture {
-            let scale = calculateAspectFitScale(for: texture, in: view.drawableSize)
+        if let texture = makeTexture(fromLatestFrame: latestFrameStore.latestValue) {
+            let scale = calculateScale(for: texture, in: view.drawableSize, contentMode: cameraContentMode)
             var uniforms = Uniforms(scale: scale)
             commandEncoder.setVertexBytes(&uniforms,
                                           length: MemoryLayout<Uniforms>.size,
@@ -231,12 +204,75 @@ extension MetalCameraRenderer {
         commandBuffer.commit()
     }
 
-    /// Calculates a scale to aspect-fit the texture within the drawable size.
-    private func calculateAspectFitScale(for texture: MTLTexture, in drawableSize: CGSize) -> SIMD2<Float> {
+    private func makeTexture(fromLatestFrame frame: PixelBufferWrapper?) -> MTLTexture? {
+        guard let textureCache = self.textureCache else {
+            DualCameraLogger.errors.error("No texture cache available")
+            return nil
+        }
+
+        guard let frame else { return nil }
+
+        let buffer = frame.buffer
+        let width = CVPixelBufferGetWidth(buffer)
+        let height = CVPixelBufferGetHeight(buffer)
+
+        var textureRef: CVMetalTexture?
+        let status = CVMetalTextureCacheCreateTextureFromImage(
+            kCFAllocatorDefault,
+            textureCache,
+            buffer,
+            nil,
+            .bgra8Unorm,
+            width,
+            height,
+            0,
+            &textureRef
+        )
+
+        guard status == kCVReturnSuccess,
+              let textureRef,
+              let metalTexture = CVMetalTextureGetTexture(textureRef) else {
+            DualCameraLogger.errors.error("Failed to create texture: \(status)")
+            return nil
+        }
+
+        return metalTexture
+    }
+
+    private func calculateScale(
+        for texture: MTLTexture,
+        in drawableSize: CGSize,
+        contentMode: DualCameraContentMode
+    ) -> SIMD2<Float> {
         let textureAspect = Float(texture.width) / Float(texture.height)
         let viewAspect = Float(drawableSize.width) / Float(drawableSize.height)
-        return textureAspect > viewAspect
+
+        switch contentMode {
+        case .aspectFill:
+            return textureAspect > viewAspect
             ? SIMD2<Float>(textureAspect / viewAspect, 1)
             : SIMD2<Float>(1, viewAspect / textureAspect)
+        case .aspectFit:
+            return textureAspect > viewAspect
+            ? SIMD2<Float>(1, viewAspect / textureAspect)
+            : SIMD2<Float>(textureAspect / viewAspect, 1)
+        }
+    }
+}
+
+private final class LatestPixelBufferStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: PixelBufferWrapper?
+
+    func store(_ newValue: PixelBufferWrapper) {
+        lock.lock()
+        value = newValue
+        lock.unlock()
+    }
+
+    var latestValue: PixelBufferWrapper? {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
     }
 }

--- a/Sources/DualCameraKit/DualCameraCameraStreamSource.swift
+++ b/Sources/DualCameraKit/DualCameraCameraStreamSource.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AVFoundation
 import UIKit
 
@@ -272,7 +273,11 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
         outputRegistry.setOutput(backOutput, for: .back)
 
         let synchronizer = AVCaptureDataOutputSynchronizer(dataOutputs: [frontOutput, backOutput])
-        synchronizer.setDelegate(self, queue: DispatchQueue(label: "DualCameraSynchronizedQueue", qos: .userInteractive))
+        let synchronizedQueue = DispatchQueue(
+            label: "DualCameraSynchronizedQueue",
+            qos: .userInteractive
+        )
+        synchronizer.setDelegate(self, queue: synchronizedQueue)
         outputSynchronizer = synchronizer
         updateVideoRotationAngle(orientationProvider.currentVideoRotationAngle)
     }

--- a/Sources/DualCameraKit/DualCameraCameraStreamSource.swift
+++ b/Sources/DualCameraKit/DualCameraCameraStreamSource.swift
@@ -337,40 +337,57 @@ extension DualCameraCameraStreamSource: AVCaptureDataOutputSynchronizerDelegate 
         didOutput synchronizedDataCollection: AVCaptureSynchronizedDataCollection
     ) {
         guard let frontOutput = outputRegistry.output(for: .front),
-              let backOutput = outputRegistry.output(for: .back),
-              let frontData = synchronizedDataCollection.synchronizedData(
-                for: frontOutput
-              ) as? AVCaptureSynchronizedSampleBufferData,
-              let backData = synchronizedDataCollection.synchronizedData(
-                for: backOutput
-              ) as? AVCaptureSynchronizedSampleBufferData else {
+              let backOutput = outputRegistry.output(for: .back) else {
             return
         }
 
-        guard !frontData.sampleBufferWasDropped, !backData.sampleBufferWasDropped else {
+        let frontFrame = frame(from: synchronizedDataCollection, output: frontOutput)
+        let backFrame = frame(from: synchronizedDataCollection, output: backOutput)
+
+        if let frontFrame {
+            frontBroadcaster.send(frontFrame.frame)
+        }
+        if let backFrame {
+            backBroadcaster.send(backFrame.frame)
+        }
+
+        guard let frontFrame, let backFrame else {
             diagnosticsStore.incrementDroppedFramePairCount()
             return
         }
 
-        let frontSampleBuffer = frontData.sampleBuffer
-        let backSampleBuffer = backData.sampleBuffer
+        let timestamp = min(frontFrame.timestamp, backFrame.timestamp)
+        let framePair = DualCameraFramePair(
+            front: frontFrame.frame,
+            back: backFrame.frame,
+            timestamp: timestamp
+        )
+        framePairBroadcaster.send(framePair)
+    }
 
-        guard let frontPixelBuffer = CMSampleBufferGetImageBuffer(frontSampleBuffer),
-              let backPixelBuffer = CMSampleBufferGetImageBuffer(backSampleBuffer) else {
-            return
+    private nonisolated func frame(
+        from synchronizedDataCollection: AVCaptureSynchronizedDataCollection,
+        output: AVCaptureVideoDataOutput
+    ) -> (frame: PixelBufferWrapper, timestamp: CMTime)? {
+        guard let data = synchronizedDataCollection.synchronizedData(
+            for: output
+        ) as? AVCaptureSynchronizedSampleBufferData else {
+            return nil
         }
 
-        let frontFrame = PixelBufferWrapper(buffer: frontPixelBuffer, sampleBuffer: frontSampleBuffer)
-        let backFrame = PixelBufferWrapper(buffer: backPixelBuffer, sampleBuffer: backSampleBuffer)
-        let timestamp = min(
-            CMSampleBufferGetPresentationTimeStamp(frontSampleBuffer),
-            CMSampleBufferGetPresentationTimeStamp(backSampleBuffer)
-        )
-        let framePair = DualCameraFramePair(front: frontFrame, back: backFrame, timestamp: timestamp)
+        guard !data.sampleBufferWasDropped else {
+            return nil
+        }
 
-        frontBroadcaster.send(frontFrame)
-        backBroadcaster.send(backFrame)
-        framePairBroadcaster.send(framePair)
+        let sampleBuffer = data.sampleBuffer
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+            return nil
+        }
+
+        return (
+            PixelBufferWrapper(buffer: pixelBuffer, sampleBuffer: sampleBuffer),
+            CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        )
     }
 }
 

--- a/Sources/DualCameraKit/DualCameraCameraStreamSource.swift
+++ b/Sources/DualCameraKit/DualCameraCameraStreamSource.swift
@@ -7,7 +7,14 @@ public protocol DualCameraCameraStreamSourcing {
     func stopSession()
     nonisolated func subscribe(to source: DualCameraSource) -> AsyncStream<PixelBufferWrapper>
     nonisolated func latestFrame(for source: DualCameraSource) -> PixelBufferWrapper?
+    nonisolated func subscribeToFramePairs() -> AsyncStream<DualCameraFramePair>
+    nonisolated func latestFramePair() -> DualCameraFramePair?
+    nonisolated func diagnostics() -> DualCameraDiagnostics
     func setTorchMode(_ mode: AVCaptureDevice.TorchMode) throws
+    func setZoomFactor(_ factor: CGFloat, for source: DualCameraSource) throws
+    func setFocusMode(_ mode: AVCaptureDevice.FocusMode, for source: DualCameraSource) throws
+    func setExposureMode(_ mode: AVCaptureDevice.ExposureMode, for source: DualCameraSource) throws
+    func setWhiteBalanceMode(_ mode: AVCaptureDevice.WhiteBalanceMode, for source: DualCameraSource) throws
 }
 
 /// Manages low-level camera access and stream production
@@ -19,20 +26,27 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
     // Stream broadcasters
     private let frontBroadcaster = PixelBufferBroadcaster()
     private let backBroadcaster = PixelBufferBroadcaster()
+    private let framePairBroadcaster = FramePairBroadcaster()
+    private let diagnosticsStore = DiagnosticsStore()
+    private let outputRegistry = CaptureOutputRegistry()
 
     // Camera I/O
     private var frontCameraInput: AVCaptureDeviceInput?
     private var backCameraInput: AVCaptureDeviceInput?
     private var frontCameraOutput: AVCaptureVideoDataOutput?
     private var backCameraOutput: AVCaptureVideoDataOutput?
+    private var outputSynchronizer: AVCaptureDataOutputSynchronizer?
+    private var interruptionObserver: NSObjectProtocol?
     private var isConfigured = false
+    private let orientationProvider: DualCameraVideoOrientationProviding
 
     // Real AVCaptureMultiCamSession ownership is intentionally process-wide for now.
     // Tests that need multiple independent owners should use mock stream sources.
     @MainActor private static var activeInstance: DualCameraCameraStreamSource?
 
     /// Initialize camera hardware interface
-    public override init() {
+    public init(orientationProvider: DualCameraVideoOrientationProviding = DeviceVideoOrientationProvider()) {
+        self.orientationProvider = orientationProvider
         super.init()
     }
 
@@ -61,6 +75,7 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
                 try configureCameras()
                 isConfigured = true
             } catch {
+                diagnosticsStore.incrementConfigurationFailureCount()
                 session.commitConfiguration()
                 throw error
             }
@@ -71,6 +86,10 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
             session.startRunning()
         }
 
+        observeSessionNotificationsIfNeeded()
+        orientationProvider.startObserving { [weak self] angle in
+            self?.updateVideoRotationAngle(angle)
+        }
         Self.activeInstance = self
     }
 
@@ -83,6 +102,12 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
 
         if Self.activeInstance === self {
             Self.activeInstance = nil
+        }
+
+        orientationProvider.stopObserving()
+        if let interruptionObserver {
+            NotificationCenter.default.removeObserver(interruptionObserver)
+            self.interruptionObserver = nil
         }
     }
 
@@ -104,6 +129,18 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
         case .back:
             return backBroadcaster.latestValue
         }
+    }
+
+    nonisolated public func subscribeToFramePairs() -> AsyncStream<DualCameraFramePair> {
+        framePairBroadcaster.subscribe()
+    }
+
+    nonisolated public func latestFramePair() -> DualCameraFramePair? {
+        framePairBroadcaster.latestValue
+    }
+
+    nonisolated public func diagnostics() -> DualCameraDiagnostics {
+        diagnosticsStore.snapshot
     }
 
     /// Sets the back-camera torch mode.
@@ -136,6 +173,41 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
         }
     }
 
+    public func setZoomFactor(_ factor: CGFloat, for source: DualCameraSource) throws {
+        let device = try cameraDevice(for: source)
+        try configureDevice(device) {
+            let clampedFactor = min(max(factor, device.minAvailableVideoZoomFactor), device.maxAvailableVideoZoomFactor)
+            device.videoZoomFactor = clampedFactor
+        }
+    }
+
+    public func setFocusMode(_ mode: AVCaptureDevice.FocusMode, for source: DualCameraSource) throws {
+        let device = try cameraDevice(for: source)
+        guard device.isFocusModeSupported(mode) else { return }
+        try configureDevice(device) {
+            device.focusMode = mode
+        }
+    }
+
+    public func setExposureMode(_ mode: AVCaptureDevice.ExposureMode, for source: DualCameraSource) throws {
+        let device = try cameraDevice(for: source)
+        guard device.isExposureModeSupported(mode) else { return }
+        try configureDevice(device) {
+            device.exposureMode = mode
+        }
+    }
+
+    public func setWhiteBalanceMode(
+        _ mode: AVCaptureDevice.WhiteBalanceMode,
+        for source: DualCameraSource
+    ) throws {
+        let device = try cameraDevice(for: source)
+        guard device.isWhiteBalanceModeSupported(mode) else { return }
+        try configureDevice(device) {
+            device.whiteBalanceMode = mode
+        }
+    }
+
     // MARK: - Private Methods
 
     @MainActor
@@ -145,18 +217,14 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
         if status == .authorized {
             return true
         } else if status == .notDetermined {
-            return await withCheckedContinuation { continuation in
-                AVCaptureDevice.requestAccess(for: .video) { granted in
-                    continuation.resume(returning: granted)
-                }
-            }
+            return await AVCaptureDevice.requestAccess(for: .video)
         }
         return false
     }
 
     private func configureCameras() throws {
         try configureCameraInputs()
-        configureVideoOutputs()
+        try configureVideoOutputs()
     }
 
     private func configureCameraInputs() throws {
@@ -182,64 +250,136 @@ public final class DualCameraCameraStreamSource: NSObject, DualCameraCameraStrea
         }
     }
 
-    private func configureVideoOutputs() {
+    private func configureVideoOutputs() throws {
         let frontOutput = AVCaptureVideoDataOutput()
         let backOutput = AVCaptureVideoDataOutput()
 
         // Set pixel format
         frontOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
         backOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        frontOutput.alwaysDiscardsLateVideoFrames = true
+        backOutput.alwaysDiscardsLateVideoFrames = true
 
-        frontOutput.setSampleBufferDelegate(self, queue: DispatchQueue(label: "FrontCameraQueue"))
-        backOutput.setSampleBufferDelegate(self, queue: DispatchQueue(label: "BackCameraQueue"))
-
-        // Add outputs to the session
-        if session.canAddOutput(frontOutput) {
-            session.addOutput(frontOutput)
-            frontCameraOutput = frontOutput
+        guard session.canAddOutput(frontOutput), session.canAddOutput(backOutput) else {
+            throw DualCameraError.configurationFailed
         }
-        if session.canAddOutput(backOutput) {
-            session.addOutput(backOutput)
-            backCameraOutput = backOutput
+
+        session.addOutput(frontOutput)
+        session.addOutput(backOutput)
+        frontCameraOutput = frontOutput
+        backCameraOutput = backOutput
+        outputRegistry.setOutput(frontOutput, for: .front)
+        outputRegistry.setOutput(backOutput, for: .back)
+
+        let synchronizer = AVCaptureDataOutputSynchronizer(dataOutputs: [frontOutput, backOutput])
+        synchronizer.setDelegate(self, queue: DispatchQueue(label: "DualCameraSynchronizedQueue", qos: .userInteractive))
+        outputSynchronizer = synchronizer
+        updateVideoRotationAngle(orientationProvider.currentVideoRotationAngle)
+    }
+
+    private func cameraDevice(for source: DualCameraSource) throws -> AVCaptureDevice {
+        switch source {
+        case .front:
+            guard let device = frontCameraInput?.device else {
+                throw DualCameraError.cameraUnavailable(position: .front)
+            }
+            return device
+        case .back:
+            guard let device = backCameraInput?.device else {
+                throw DualCameraError.cameraUnavailable(position: .back)
+            }
+            return device
+        }
+    }
+
+    private func configureDevice(_ device: AVCaptureDevice, changes: () throws -> Void) throws {
+        do {
+            try device.lockForConfiguration()
+            defer { device.unlockForConfiguration() }
+            try changes()
+        } catch {
+            throw DualCameraError.configurationFailed
+        }
+    }
+
+    private func updateVideoRotationAngle(_ angle: CGFloat) {
+        for output in [frontCameraOutput, backCameraOutput] {
+            guard let connection = output?.connection(with: .video),
+                  connection.isVideoRotationAngleSupported(angle) else {
+                continue
+            }
+            connection.videoRotationAngle = angle
+        }
+    }
+
+    private func observeSessionNotificationsIfNeeded() {
+        guard interruptionObserver == nil else { return }
+
+        interruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVCaptureSession.wasInterruptedNotification,
+            object: session,
+            queue: .main
+        ) { [diagnosticsStore] _ in
+            diagnosticsStore.incrementSessionInterruptionCount()
         }
     }
 }
 
 // MARK: - AVCapture Delegate Implementation
-extension DualCameraCameraStreamSource: AVCaptureVideoDataOutputSampleBufferDelegate {
-    /// Receives camera frames from AVFoundation on background threads
-    /// This method is called by the system on capture queue threads
-    nonisolated public func captureOutput(
-        _ output: AVCaptureOutput,
-        didOutput sampleBuffer: CMSampleBuffer,
-        from connection: AVCaptureConnection
+extension DualCameraCameraStreamSource: AVCaptureDataOutputSynchronizerDelegate {
+    nonisolated public func dataOutputSynchronizer(
+        _ synchronizer: AVCaptureDataOutputSynchronizer,
+        didOutput synchronizedDataCollection: AVCaptureSynchronizedDataCollection
     ) {
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+        guard let frontOutput = outputRegistry.output(for: .front),
+              let backOutput = outputRegistry.output(for: .back),
+              let frontData = synchronizedDataCollection.synchronizedData(
+                for: frontOutput
+              ) as? AVCaptureSynchronizedSampleBufferData,
+              let backData = synchronizedDataCollection.synchronizedData(
+                for: backOutput
+              ) as? AVCaptureSynchronizedSampleBufferData else {
             return
         }
 
-        // Set portrait orientation for the captured camera frames.
-        if connection.isVideoRotationAngleSupported(90) {
-            connection.videoRotationAngle = 90
+        guard !frontData.sampleBufferWasDropped, !backData.sampleBufferWasDropped else {
+            diagnosticsStore.incrementDroppedFramePairCount()
+            return
         }
 
-        // Broadcast to appropriate stream
-        let wrappedBuffer = PixelBufferWrapper(buffer: pixelBuffer)
-        let isFrontCamera = connection.inputPorts.contains { $0.sourceDevicePosition == .front }
+        let frontSampleBuffer = frontData.sampleBuffer
+        let backSampleBuffer = backData.sampleBuffer
 
-        if isFrontCamera {
-            frontBroadcaster.send(wrappedBuffer)
-        } else {
-            backBroadcaster.send(wrappedBuffer)
+        guard let frontPixelBuffer = CMSampleBufferGetImageBuffer(frontSampleBuffer),
+              let backPixelBuffer = CMSampleBufferGetImageBuffer(backSampleBuffer) else {
+            return
         }
+
+        let frontFrame = PixelBufferWrapper(buffer: frontPixelBuffer, sampleBuffer: frontSampleBuffer)
+        let backFrame = PixelBufferWrapper(buffer: backPixelBuffer, sampleBuffer: backSampleBuffer)
+        let timestamp = min(
+            CMSampleBufferGetPresentationTimeStamp(frontSampleBuffer),
+            CMSampleBufferGetPresentationTimeStamp(backSampleBuffer)
+        )
+        let framePair = DualCameraFramePair(front: frontFrame, back: backFrame, timestamp: timestamp)
+
+        frontBroadcaster.send(frontFrame)
+        backBroadcaster.send(backFrame)
+        framePairBroadcaster.send(framePair)
     }
 }
 
 public final class DualCameraMockCameraStreamSource: DualCameraCameraStreamSourcing {
     public private(set) var torchMode: AVCaptureDevice.TorchMode = .off
+    public private(set) var zoomFactors: [DualCameraSource: CGFloat] = [:]
+    public private(set) var focusModes: [DualCameraSource: AVCaptureDevice.FocusMode] = [:]
+    public private(set) var exposureModes: [DualCameraSource: AVCaptureDevice.ExposureMode] = [:]
+    public private(set) var whiteBalanceModes: [DualCameraSource: AVCaptureDevice.WhiteBalanceMode] = [:]
 
     private let frontBroadcaster = PixelBufferBroadcaster()
     private let backBroadcaster = PixelBufferBroadcaster()
+    private let framePairBroadcaster = FramePairBroadcaster()
+    private let diagnosticsStore = DiagnosticsStore()
     private let animated: Bool
     private var frameTask: Task<Void, Never>?
 
@@ -290,12 +430,45 @@ public final class DualCameraMockCameraStreamSource: DualCameraCameraStreamSourc
         }
     }
 
+    nonisolated public func subscribeToFramePairs() -> AsyncStream<DualCameraFramePair> {
+        framePairBroadcaster.subscribe()
+    }
+
+    nonisolated public func latestFramePair() -> DualCameraFramePair? {
+        framePairBroadcaster.latestValue
+    }
+
+    nonisolated public func diagnostics() -> DualCameraDiagnostics {
+        diagnosticsStore.snapshot
+    }
+
     public func setTorchMode(_ mode: AVCaptureDevice.TorchMode) throws {
         torchMode = mode
     }
 
+    public func setZoomFactor(_ factor: CGFloat, for source: DualCameraSource) throws {
+        zoomFactors[source] = factor
+    }
+
+    public func setFocusMode(_ mode: AVCaptureDevice.FocusMode, for source: DualCameraSource) throws {
+        focusModes[source] = mode
+    }
+
+    public func setExposureMode(_ mode: AVCaptureDevice.ExposureMode, for source: DualCameraSource) throws {
+        exposureModes[source] = mode
+    }
+
+    public func setWhiteBalanceMode(
+        _ mode: AVCaptureDevice.WhiteBalanceMode,
+        for source: DualCameraSource
+    ) throws {
+        whiteBalanceModes[source] = mode
+    }
+
     private func sendMockFrames(sequence: Int) {
         let mockSize = CGSize(width: 360, height: 640)
+        var frontFrame: PixelBufferWrapper?
+        var backFrame: PixelBufferWrapper?
 
         if let frontBuffer = mockPixelBuffer(
             size: mockSize,
@@ -303,7 +476,9 @@ public final class DualCameraMockCameraStreamSource: DualCameraCameraStreamSourc
             saturation: 1,
             brightness: 1
         ) {
-            frontBroadcaster.send(PixelBufferWrapper(buffer: frontBuffer))
+            let wrapper = PixelBufferWrapper(buffer: frontBuffer)
+            frontFrame = wrapper
+            frontBroadcaster.send(wrapper)
         }
 
         if let backBuffer = mockPixelBuffer(
@@ -312,7 +487,13 @@ public final class DualCameraMockCameraStreamSource: DualCameraCameraStreamSourc
             saturation: 1,
             brightness: 0.58
         ) {
-            backBroadcaster.send(PixelBufferWrapper(buffer: backBuffer))
+            let wrapper = PixelBufferWrapper(buffer: backBuffer)
+            backFrame = wrapper
+            backBroadcaster.send(wrapper)
+        }
+
+        if let frontFrame, let backFrame {
+            framePairBroadcaster.send(DualCameraFramePair(front: frontFrame, back: backFrame))
         }
     }
 
@@ -330,5 +511,57 @@ public final class DualCameraMockCameraStreamSource: DualCameraCameraStreamSourc
         )
         .asImage(size)
         .pixelBuffer()
+    }
+}
+
+private final class CaptureOutputRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var outputs: [DualCameraSource: AVCaptureVideoDataOutput] = [:]
+
+    func setOutput(_ output: AVCaptureVideoDataOutput, for source: DualCameraSource) {
+        lock.lock()
+        outputs[source] = output
+        lock.unlock()
+    }
+
+    func output(for source: DualCameraSource) -> AVCaptureVideoDataOutput? {
+        lock.lock()
+        defer { lock.unlock() }
+        return outputs[source]
+    }
+}
+
+private final class DiagnosticsStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var droppedFramePairCount = 0
+    private var sessionInterruptionCount = 0
+    private var configurationFailureCount = 0
+
+    var snapshot: DualCameraDiagnostics {
+        lock.lock()
+        defer { lock.unlock() }
+        return DualCameraDiagnostics(
+            droppedFramePairCount: droppedFramePairCount,
+            sessionInterruptionCount: sessionInterruptionCount,
+            configurationFailureCount: configurationFailureCount
+        )
+    }
+
+    func incrementDroppedFramePairCount() {
+        lock.lock()
+        droppedFramePairCount += 1
+        lock.unlock()
+    }
+
+    func incrementSessionInterruptionCount() {
+        lock.lock()
+        sessionInterruptionCount += 1
+        lock.unlock()
+    }
+
+    func incrementConfigurationFailureCount() {
+        lock.lock()
+        configurationFailureCount += 1
+        lock.unlock()
     }
 }

--- a/Sources/DualCameraKit/DualCameraContentMode.swift
+++ b/Sources/DualCameraKit/DualCameraContentMode.swift
@@ -1,0 +1,8 @@
+/// Describes how camera imagery is fitted into a preview or capture region.
+public enum DualCameraContentMode: Sendable {
+    /// Fill the target region while preserving aspect ratio. Content may be cropped.
+    case aspectFill
+
+    /// Fit the whole image inside the target region while preserving aspect ratio.
+    case aspectFit
+}

--- a/Sources/DualCameraKit/DualCameraController.swift
+++ b/Sources/DualCameraKit/DualCameraController.swift
@@ -11,8 +11,19 @@ public protocol DualCameraControlling {
 
     func captureRawPhotos(displayScale: CGFloat) async throws -> (front: UIImage, back: UIImage)
     func capturePhoto(layout: DualCameraLayout, outputSize: CGSize, displayScale: CGFloat) async throws -> UIImage
+    func capturePhoto(
+        layout: DualCameraLayout,
+        outputSize: CGSize,
+        displayScale: CGFloat,
+        contentMode: DualCameraContentMode
+    ) async throws -> UIImage
 
     func setTorchMode(_ mode: AVCaptureDevice.TorchMode) throws
+    func setZoomFactor(_ factor: CGFloat, for source: DualCameraSource) throws
+    func setFocusMode(_ mode: AVCaptureDevice.FocusMode, for source: DualCameraSource) throws
+    func setExposureMode(_ mode: AVCaptureDevice.ExposureMode, for source: DualCameraSource) throws
+    func setWhiteBalanceMode(_ mode: AVCaptureDevice.WhiteBalanceMode, for source: DualCameraSource) throws
+    func diagnostics() -> DualCameraDiagnostics
 }
 
 public extension DualCameraControlling {
@@ -22,6 +33,28 @@ public extension DualCameraControlling {
 
     func capturePhoto(layout: DualCameraLayout, outputSize: CGSize) async throws -> UIImage {
         try await capturePhoto(layout: layout, outputSize: outputSize, displayScale: 1)
+    }
+
+    func capturePhoto(
+        layout: DualCameraLayout,
+        outputSize: CGSize,
+        contentMode: DualCameraContentMode
+    ) async throws -> UIImage {
+        try await capturePhoto(
+            layout: layout,
+            outputSize: outputSize,
+            displayScale: 1,
+            contentMode: contentMode
+        )
+    }
+
+    func capturePhoto(layout: DualCameraLayout, outputSize: CGSize, displayScale: CGFloat) async throws -> UIImage {
+        try await capturePhoto(
+            layout: layout,
+            outputSize: outputSize,
+            displayScale: displayScale,
+            contentMode: .aspectFill
+        )
     }
 }
 
@@ -132,8 +165,31 @@ public final class DualCameraController: DualCameraControlling {
         try streamSource.setTorchMode(mode)
     }
 
+    public func setZoomFactor(_ factor: CGFloat, for source: DualCameraSource) throws {
+        try streamSource.setZoomFactor(factor, for: source)
+    }
+
+    public func setFocusMode(_ mode: AVCaptureDevice.FocusMode, for source: DualCameraSource) throws {
+        try streamSource.setFocusMode(mode, for: source)
+    }
+
+    public func setExposureMode(_ mode: AVCaptureDevice.ExposureMode, for source: DualCameraSource) throws {
+        try streamSource.setExposureMode(mode, for: source)
+    }
+
+    public func setWhiteBalanceMode(
+        _ mode: AVCaptureDevice.WhiteBalanceMode,
+        for source: DualCameraSource
+    ) throws {
+        try streamSource.setWhiteBalanceMode(mode, for: source)
+    }
+
+    public func diagnostics() -> DualCameraDiagnostics {
+        streamSource.diagnostics()
+    }
+
     public func captureRawPhotos(displayScale: CGFloat) async throws -> (front: UIImage, back: UIImage) {
-        let buffers = try latestBuffers()
+        let buffers = try latestFramePair()
         return try await photoCapturer.captureRawPhotos(
             frontBuffer: buffers.front.buffer,
             backBuffer: buffers.back.buffer,
@@ -144,15 +200,17 @@ public final class DualCameraController: DualCameraControlling {
     public func capturePhoto(
         layout: DualCameraLayout,
         outputSize: CGSize,
-        displayScale: CGFloat
+        displayScale: CGFloat,
+        contentMode: DualCameraContentMode
     ) async throws -> UIImage {
-        let buffers = try latestBuffers()
+        let buffers = try latestFramePair()
         return try await photoCapturer.captureComposedPhoto(
             frontBuffer: buffers.front.buffer,
             backBuffer: buffers.back.buffer,
             layout: layout,
             outputSize: outputSize,
-            displayScale: displayScale
+            displayScale: displayScale,
+            contentMode: contentMode
         )
     }
 
@@ -171,20 +229,19 @@ public final class DualCameraController: DualCameraControlling {
         return renderer
     }
 
-    private func latestBuffers() throws -> (front: PixelBufferWrapper, back: PixelBufferWrapper) {
-        guard let front = streamSource.latestFrame(for: .front),
-              let back = streamSource.latestFrame(for: .back) else {
+    private func latestFramePair() throws -> DualCameraFramePair {
+        guard let framePair = streamSource.latestFramePair() else {
             throw DualCameraError.captureFailure(.noFrameAvailable)
         }
-        return (front, back)
+        return framePair
     }
 
     private func connectStream(for source: DualCameraSource, renderer: CameraRenderer) {
         let stream = subscribe(to: source)
-        let task = Task { @MainActor in
+        let task = Task {
             for await buffer in stream {
                 if Task.isCancelled { break }
-                renderer.update(with: buffer.buffer)
+                renderer.update(with: buffer)
             }
         }
         streamTasks[source] = task

--- a/Sources/DualCameraKit/DualCameraDiagnostics.swift
+++ b/Sources/DualCameraKit/DualCameraDiagnostics.swift
@@ -1,0 +1,16 @@
+/// Lightweight runtime diagnostics for capture-session health.
+public struct DualCameraDiagnostics: Equatable, Sendable {
+    public let droppedFramePairCount: Int
+    public let sessionInterruptionCount: Int
+    public let configurationFailureCount: Int
+
+    public init(
+        droppedFramePairCount: Int = 0,
+        sessionInterruptionCount: Int = 0,
+        configurationFailureCount: Int = 0
+    ) {
+        self.droppedFramePairCount = droppedFramePairCount
+        self.sessionInterruptionCount = sessionInterruptionCount
+        self.configurationFailureCount = configurationFailureCount
+    }
+}

--- a/Sources/DualCameraKit/DualCameraDisplayView.swift
+++ b/Sources/DualCameraKit/DualCameraDisplayView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 public struct DualCameraDisplayView: View {
     private let controller: DualCameraControlling
     private let layout: DualCameraLayout
+    private let contentMode: DualCameraContentMode
     private let overlayInsets: EdgeInsets
     private let layoutResolver = DualCameraLayoutResolver()
 
@@ -12,10 +13,12 @@ public struct DualCameraDisplayView: View {
             miniCamera: .front,
             miniCameraPosition: .bottomTrailing
         ),
+        contentMode: DualCameraContentMode = .aspectFill,
         overlayInsets: EdgeInsets = EdgeInsets()
     ) {
         self.controller = controller
         self.layout = layout
+        self.contentMode = contentMode
         self.overlayInsets = overlayInsets
     }
 
@@ -48,7 +51,10 @@ public struct DualCameraDisplayView: View {
         _ region: DualCameraResolvedLayout.CameraRegion,
         cornerRadius: CGFloat = 0
     ) -> some View {
-        DualCameraRendererView(renderer: controller.getRenderer(for: region.source))
+        DualCameraRendererView(
+            renderer: controller.getRenderer(for: region.source),
+            contentMode: contentMode
+        )
             .frame(width: region.frame.width, height: region.frame.height)
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .position(x: region.frame.midX, y: region.frame.midY)

--- a/Sources/DualCameraKit/DualCameraEnvironment.swift
+++ b/Sources/DualCameraKit/DualCameraEnvironment.swift
@@ -28,4 +28,9 @@ public struct DualCameraEnvironment {
 
 @MainActor
 // swiftlint:disable:next identifier_name
+@available(
+    *,
+    deprecated,
+    message: "Inject DualCameraEnvironment or DualCameraControlling explicitly instead of using process-wide mutable state."
+)
 public var CurrentDualCameraEnvironment = DualCameraEnvironment()

--- a/Sources/DualCameraKit/DualCameraEnvironment.swift
+++ b/Sources/DualCameraKit/DualCameraEnvironment.swift
@@ -27,10 +27,10 @@ public struct DualCameraEnvironment {
 }
 
 @MainActor
-// swiftlint:disable:next identifier_name
 @available(
     *,
     deprecated,
-    message: "Inject DualCameraEnvironment or DualCameraControlling explicitly instead of using process-wide mutable state."
+    message: "Inject dependencies explicitly instead of using process-wide mutable state."
 )
+// swiftlint:disable:next identifier_name
 public var CurrentDualCameraEnvironment = DualCameraEnvironment()

--- a/Sources/DualCameraKit/DualCameraFramePair.swift
+++ b/Sources/DualCameraKit/DualCameraFramePair.swift
@@ -1,0 +1,14 @@
+import AVFoundation
+
+/// A synchronized front/back camera frame pair.
+public struct DualCameraFramePair: Sendable {
+    public let front: PixelBufferWrapper
+    public let back: PixelBufferWrapper
+    public let timestamp: CMTime?
+
+    public init(front: PixelBufferWrapper, back: PixelBufferWrapper, timestamp: CMTime? = nil) {
+        self.front = front
+        self.back = back
+        self.timestamp = timestamp
+    }
+}

--- a/Sources/DualCameraKit/DualCameraLayout.swift
+++ b/Sources/DualCameraKit/DualCameraLayout.swift
@@ -1,5 +1,3 @@
-import SwiftUI
-
 /// Defines different layouts for dual-camera display
 public enum DualCameraLayout: Hashable, Sendable {
 
@@ -10,87 +8,5 @@ public enum DualCameraLayout: Hashable, Sendable {
     /// Positions for mini camera
     public enum MiniCameraPosition: CaseIterable, Hashable, Sendable {
         case topLeading, topTrailing, bottomLeading, bottomTrailing
-
-        func alignment() -> Alignment {
-            switch self {
-            case .topLeading:     return .topLeading
-            case .topTrailing:    return .topTrailing
-            case .bottomLeading:  return .bottomLeading
-            case .bottomTrailing: return .bottomTrailing
-            }
-        }
-
-        var title: String {
-            switch self {
-            case .topLeading:     return "Top Left"
-            case .topTrailing:    return "Top Right"
-            case .bottomLeading:  return "Bottom Left"
-            case .bottomTrailing: return "Bottom Right"
-            }
-        }
-    }
-}
-
-extension DualCameraLayout {
-
-    public static var menuItems: [MenuItem] {
-        let standardItems: [MenuItem] = [
-            .entry(title: DualCameraLayout.sideBySide.title, layout: .sideBySide),
-            .entry(title: DualCameraLayout.stackedVertical.title, layout: .stackedVertical)
-        ]
-
-        // PiP layouts grouped in a submenu
-        var pipItems: [MenuItem] = []
-
-        // Front camera options
-        for position in MiniCameraPosition.allCases {
-            let layout: DualCameraLayout = .piP(miniCamera: .front, miniCameraPosition: position)
-            pipItems.append(.entry(title: layout.title, layout: layout))
-        }
-
-        // Back camera options
-        for position in MiniCameraPosition.allCases {
-            let layout: DualCameraLayout = .piP(miniCamera: .back, miniCameraPosition: position)
-            pipItems.append(.entry(title: layout.title, layout: layout))
-        }
-
-        return standardItems + [.submenu(title: "PiP Mode", items: pipItems)]
-    }
-
-    public enum MenuItem: Identifiable {
-        public var id: String {
-            switch self {
-            case .entry(let title, let layout):
-                return "entry_\(title)_\(layout.idString)"
-            case .submenu(let title, _):
-                return "submenu_\(title)"
-            }
-        }
-
-        case entry(title: String, layout: DualCameraLayout)
-        case submenu(title: String, items: [MenuItem])
-    }
-
-    public var title: String {
-        switch self {
-        case .sideBySide:
-            return "Side by Side"
-        case .stackedVertical:
-            return "Stacked Vertical"
-        case .piP(let miniCamera, let position):
-            let cameraText = miniCamera == .front ? "Front" : "Back"
-            return "\(cameraText) Mini - \(position.title)"
-        }
-    }
-
-    var idString: String {
-        switch self {
-        case .sideBySide:
-            return "sideBySide"
-        case .stackedVertical:
-            return "stackedVertical"
-        case .piP(let miniCamera, let position):
-            return "fullScreenWithMini_\(miniCamera)_\(position)"
-        }
     }
 }

--- a/Sources/DualCameraKit/DualCameraPhotoCapturing.swift
+++ b/Sources/DualCameraKit/DualCameraPhotoCapturing.swift
@@ -8,6 +8,7 @@ public protocol DualCameraPhotoCapturing: AnyObject, Sendable {
         displayScale: CGFloat
     ) async throws -> (front: UIImage, back: UIImage)
 
+    // swiftlint:disable:next function_parameter_count
     func captureComposedPhoto(
         frontBuffer: CVPixelBuffer,
         backBuffer: CVPixelBuffer,
@@ -78,6 +79,7 @@ public class DualCameraPhotoCapturer: DualCameraPhotoCapturing {
         )
     }
 
+    // swiftlint:disable:next function_parameter_count
     public func captureComposedPhoto(
         frontBuffer: CVPixelBuffer,
         backBuffer: CVPixelBuffer,

--- a/Sources/DualCameraKit/DualCameraPhotoCapturing.swift
+++ b/Sources/DualCameraKit/DualCameraPhotoCapturing.swift
@@ -13,7 +13,8 @@ public protocol DualCameraPhotoCapturing: AnyObject, Sendable {
         backBuffer: CVPixelBuffer,
         layout: DualCameraLayout,
         outputSize: CGSize,
-        displayScale: CGFloat
+        displayScale: CGFloat,
+        contentMode: DualCameraContentMode
     ) async throws -> UIImage
 }
 
@@ -36,7 +37,25 @@ public extension DualCameraPhotoCapturing {
             backBuffer: backBuffer,
             layout: layout,
             outputSize: outputSize,
-            displayScale: 1
+            displayScale: 1,
+            contentMode: .aspectFill
+        )
+    }
+
+    func captureComposedPhoto(
+        frontBuffer: CVPixelBuffer,
+        backBuffer: CVPixelBuffer,
+        layout: DualCameraLayout,
+        outputSize: CGSize,
+        displayScale: CGFloat
+    ) async throws -> UIImage {
+        try await captureComposedPhoto(
+            frontBuffer: frontBuffer,
+            backBuffer: backBuffer,
+            layout: layout,
+            outputSize: outputSize,
+            displayScale: displayScale,
+            contentMode: .aspectFill
         )
     }
 }
@@ -64,7 +83,8 @@ public class DualCameraPhotoCapturer: DualCameraPhotoCapturing {
         backBuffer: CVPixelBuffer,
         layout: DualCameraLayout,
         outputSize: CGSize,
-        displayScale: CGFloat
+        displayScale: CGFloat,
+        contentMode: DualCameraContentMode
     ) async throws -> UIImage {
         guard outputSize.width > 0, outputSize.height > 0 else {
             throw DualCameraError.captureFailure(.unknownDimensions)
@@ -84,7 +104,12 @@ public class DualCameraPhotoCapturer: DualCameraPhotoCapturing {
 
             for region in resolvedLayout.regionsInDrawingOrder {
                 let image = region.source == .front ? frontImage : backImage
-                draw(image, in: region.frame, cornerRadius: cornerRadius(for: region, layout: layout))
+                draw(
+                    image,
+                    in: region.frame,
+                    cornerRadius: cornerRadius(for: region, layout: layout),
+                    contentMode: contentMode
+                )
             }
         }
     }
@@ -98,7 +123,12 @@ public class DualCameraPhotoCapturer: DualCameraPhotoCapturing {
         return UIImage(cgImage: cgImage, scale: displayScale, orientation: .up)
     }
 
-    private func draw(_ image: UIImage, in targetRect: CGRect, cornerRadius: CGFloat) {
+    private func draw(
+        _ image: UIImage,
+        in targetRect: CGRect,
+        cornerRadius: CGFloat,
+        contentMode: DualCameraContentMode
+    ) {
         let context = UIGraphicsGetCurrentContext()
         context?.saveGState()
         defer { context?.restoreGState() }
@@ -108,7 +138,7 @@ public class DualCameraPhotoCapturer: DualCameraPhotoCapturing {
             clipPath.addClip()
         }
 
-        image.draw(in: aspectFitRect(for: image.size, in: targetRect))
+        image.draw(in: contentRect(for: image.size, in: targetRect, contentMode: contentMode))
     }
 
     private func cornerRadius(for region: DualCameraResolvedLayout.CameraRegion, layout: DualCameraLayout) -> CGFloat {
@@ -118,12 +148,21 @@ public class DualCameraPhotoCapturer: DualCameraPhotoCapturing {
         return 10
     }
 
-    private func aspectFitRect(for sourceSize: CGSize, in targetRect: CGRect) -> CGRect {
+    private func contentRect(
+        for sourceSize: CGSize,
+        in targetRect: CGRect,
+        contentMode: DualCameraContentMode
+    ) -> CGRect {
         guard sourceSize.width > 0, sourceSize.height > 0 else { return targetRect }
 
         let widthRatio = targetRect.width / sourceSize.width
         let heightRatio = targetRect.height / sourceSize.height
-        let scale = min(widthRatio, heightRatio)
+        let scale = switch contentMode {
+        case .aspectFill:
+            max(widthRatio, heightRatio)
+        case .aspectFit:
+            min(widthRatio, heightRatio)
+        }
         let size = CGSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
 
         return CGRect(

--- a/Sources/DualCameraKit/DualCameraRendererView.swift
+++ b/Sources/DualCameraKit/DualCameraRendererView.swift
@@ -2,17 +2,21 @@ import SwiftUI
 
 public struct DualCameraRendererView: UIViewRepresentable {
     private let renderer: CameraRenderer
+    private let contentMode: DualCameraContentMode
 
     /// Create renderer view
-    public init(renderer: CameraRenderer) {
+    public init(renderer: CameraRenderer, contentMode: DualCameraContentMode = .aspectFill) {
         self.renderer = renderer
+        self.contentMode = contentMode
     }
 
     public func makeUIView(context: Context) -> UIView {
-        renderer.view
+        renderer.cameraContentMode = contentMode
+        return renderer.view
     }
 
     public func updateUIView(_ uiView: UIView, context: Context) {
+        renderer.cameraContentMode = contentMode
         // Updates are driven directly by camera-stream tasks.
     }
 }

--- a/Sources/DualCameraKit/DualCameraShaders.metal
+++ b/Sources/DualCameraKit/DualCameraShaders.metal
@@ -1,12 +1,6 @@
 #include <metal_stdlib>
 using namespace metal;
 
-struct MixerParameters
-{
-    float2 pipPosition;
-    float2 pipSize;
-};
-
 struct VertexOut {
     float4 position [[position]];
     float2 texCoord;

--- a/Sources/DualCameraKit/DualCameraSource.swift
+++ b/Sources/DualCameraKit/DualCameraSource.swift
@@ -1,3 +1,3 @@
-public enum DualCameraSource: Hashable, Sendable {
+public enum DualCameraSource: CaseIterable, Hashable, Sendable {
     case front, back
 }

--- a/Sources/DualCameraKit/DualCameraVideoOrientationProvider.swift
+++ b/Sources/DualCameraKit/DualCameraVideoOrientationProvider.swift
@@ -11,11 +11,12 @@ public protocol DualCameraVideoOrientationProviding: AnyObject {
 public final class DeviceVideoOrientationProvider: DualCameraVideoOrientationProviding {
     private var observer: NSObjectProtocol?
     private var onChange: (@MainActor @Sendable (CGFloat) -> Void)?
+    private var lastKnownVideoRotationAngle: CGFloat = 90
 
     public init() {}
 
     public var currentVideoRotationAngle: CGFloat {
-        Self.videoRotationAngle(for: UIDevice.current.orientation)
+        videoRotationAngle(for: UIDevice.current.orientation)
     }
 
     public func startObserving(_ onChange: @escaping @MainActor @Sendable (CGFloat) -> Void) {
@@ -47,7 +48,15 @@ public final class DeviceVideoOrientationProvider: DualCameraVideoOrientationPro
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
     }
 
-    static func videoRotationAngle(for orientation: UIDeviceOrientation) -> CGFloat {
+    func videoRotationAngle(for orientation: UIDeviceOrientation) -> CGFloat {
+        guard let rotationAngle = Self.videoRotationAngle(for: orientation) else {
+            return lastKnownVideoRotationAngle
+        }
+        lastKnownVideoRotationAngle = rotationAngle
+        return rotationAngle
+    }
+
+    static func videoRotationAngle(for orientation: UIDeviceOrientation) -> CGFloat? {
         switch orientation {
         case .portrait:
             return 90
@@ -58,9 +67,9 @@ public final class DeviceVideoOrientationProvider: DualCameraVideoOrientationPro
         case .landscapeRight:
             return 180
         case .faceUp, .faceDown, .unknown:
-            return 90
+            return nil
         @unknown default:
-            return 90
+            return nil
         }
     }
 }

--- a/Sources/DualCameraKit/DualCameraVideoOrientationProvider.swift
+++ b/Sources/DualCameraKit/DualCameraVideoOrientationProvider.swift
@@ -1,0 +1,66 @@
+import UIKit
+
+@MainActor
+public protocol DualCameraVideoOrientationProviding: AnyObject {
+    var currentVideoRotationAngle: CGFloat { get }
+    func startObserving(_ onChange: @escaping @MainActor @Sendable (CGFloat) -> Void)
+    func stopObserving()
+}
+
+@MainActor
+public final class DeviceVideoOrientationProvider: DualCameraVideoOrientationProviding {
+    private var observer: NSObjectProtocol?
+    private var onChange: (@MainActor @Sendable (CGFloat) -> Void)?
+
+    public init() {}
+
+    public var currentVideoRotationAngle: CGFloat {
+        Self.videoRotationAngle(for: UIDevice.current.orientation)
+    }
+
+    public func startObserving(_ onChange: @escaping @MainActor @Sendable (CGFloat) -> Void) {
+        self.onChange = onChange
+        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+
+        if observer == nil {
+            observer = NotificationCenter.default.addObserver(
+                forName: UIDevice.orientationDidChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                guard let self else { return }
+                Task { @MainActor in
+                    self.onChange?(self.currentVideoRotationAngle)
+                }
+            }
+        }
+
+        onChange(currentVideoRotationAngle)
+    }
+
+    public func stopObserving() {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
+        onChange = nil
+        UIDevice.current.endGeneratingDeviceOrientationNotifications()
+    }
+
+    static func videoRotationAngle(for orientation: UIDeviceOrientation) -> CGFloat {
+        switch orientation {
+        case .portrait:
+            return 90
+        case .portraitUpsideDown:
+            return 270
+        case .landscapeLeft:
+            return 0
+        case .landscapeRight:
+            return 180
+        case .faceUp, .faceDown, .unknown:
+            return 90
+        @unknown default:
+            return 90
+        }
+    }
+}

--- a/Sources/DualCameraKit/FramePairBroadcaster.swift
+++ b/Sources/DualCameraKit/FramePairBroadcaster.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+final class FramePairBroadcaster: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [UUID: AsyncStream<DualCameraFramePair>.Continuation] = [:]
+    private var latestFramePair: DualCameraFramePair?
+
+    func send(_ framePair: DualCameraFramePair) {
+        lock.lock()
+        latestFramePair = framePair
+        let activeContinuations = continuations
+        lock.unlock()
+
+        for continuation in activeContinuations.values {
+            continuation.yield(framePair)
+        }
+    }
+
+    var latestValue: DualCameraFramePair? {
+        lock.lock()
+        defer { lock.unlock() }
+        return latestFramePair
+    }
+
+    func subscribe() -> AsyncStream<DualCameraFramePair> {
+        let id = UUID()
+
+        return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            lock.lock()
+            continuations[id] = continuation
+            let bufferedValue = latestFramePair
+            lock.unlock()
+
+            if let bufferedValue {
+                continuation.yield(bufferedValue)
+            }
+
+            continuation.onTermination = { [weak self] _ in
+                guard let self else { return }
+                self.lock.lock()
+                self.continuations.removeValue(forKey: id)
+                self.lock.unlock()
+            }
+        }
+    }
+}

--- a/Sources/DualCameraKit/PixelBufferWrapper.swift
+++ b/Sources/DualCameraKit/PixelBufferWrapper.swift
@@ -13,5 +13,11 @@ import AVFoundation
 ///   copy of the pixel data. Use this wrapper only when you're certain your
 ///   usage of `CVPixelBuffer` is read-only or otherwise thread-safe.
 public struct PixelBufferWrapper: @unchecked Sendable {
-    let buffer: CVPixelBuffer
+    public let buffer: CVPixelBuffer
+    private let sampleBuffer: CMSampleBuffer?
+
+    public init(buffer: CVPixelBuffer, sampleBuffer: CMSampleBuffer? = nil) {
+        self.buffer = buffer
+        self.sampleBuffer = sampleBuffer
+    }
 }

--- a/Sources/DualCameraKitUI/DualCameraLayoutMenu.swift
+++ b/Sources/DualCameraKitUI/DualCameraLayoutMenu.swift
@@ -1,0 +1,69 @@
+import DualCameraKit
+
+public extension DualCameraLayout {
+    static var menuItems: [MenuItem] {
+        let standardItems: [MenuItem] = [
+            .entry(title: DualCameraLayout.sideBySide.title, layout: .sideBySide),
+            .entry(title: DualCameraLayout.stackedVertical.title, layout: .stackedVertical)
+        ]
+
+        let pipItems = DualCameraSource.allCases.flatMap { source in
+            MiniCameraPosition.allCases.map { position in
+                let layout = DualCameraLayout.piP(miniCamera: source, miniCameraPosition: position)
+                return MenuItem.entry(title: layout.title, layout: layout)
+            }
+        }
+
+        return standardItems + [.submenu(title: "PiP Mode", items: pipItems)]
+    }
+
+    enum MenuItem: Identifiable {
+        public var id: String {
+            switch self {
+            case .entry(let title, let layout):
+                return "entry_\(title)_\(layout.idString)"
+            case .submenu(let title, _):
+                return "submenu_\(title)"
+            }
+        }
+
+        case entry(title: String, layout: DualCameraLayout)
+        case submenu(title: String, items: [MenuItem])
+    }
+
+    var title: String {
+        switch self {
+        case .sideBySide:
+            return "Side by Side"
+        case .stackedVertical:
+            return "Stacked Vertical"
+        case .piP(let miniCamera, let position):
+            let cameraText = miniCamera == .front ? "Front" : "Back"
+            return "\(cameraText) Mini - \(position.title)"
+        }
+    }
+}
+
+private extension DualCameraLayout.MiniCameraPosition {
+    var title: String {
+        switch self {
+        case .topLeading:     return "Top Left"
+        case .topTrailing:    return "Top Right"
+        case .bottomLeading:  return "Bottom Left"
+        case .bottomTrailing: return "Bottom Right"
+        }
+    }
+}
+
+private extension DualCameraLayout {
+    var idString: String {
+        switch self {
+        case .sideBySide:
+            return "sideBySide"
+        case .stackedVertical:
+            return "stackedVertical"
+        case .piP(let miniCamera, let position):
+            return "fullScreenWithMini_\(miniCamera)_\(position)"
+        }
+    }
+}

--- a/Sources/DualCameraKitUI/DualCameraScreen.swift
+++ b/Sources/DualCameraKitUI/DualCameraScreen.swift
@@ -22,7 +22,8 @@ public struct DualCameraScreen: View {
             ZStack {
                 DualCameraDisplayView(
                     controller: viewModel.controller,
-                    layout: viewModel.cameraLayout
+                    layout: viewModel.cameraLayout,
+                    contentMode: viewModel.contentMode
                 )
                 .ignoresSafeArea()
                 .overlay(viewModel.isSettingsButtonVisible ? settingsButton : nil, alignment: .topLeading)

--- a/Sources/DualCameraKitUI/DualCameraViewModel.swift
+++ b/Sources/DualCameraKitUI/DualCameraViewModel.swift
@@ -31,6 +31,7 @@ public final class DualCameraViewModel {
     private(set) var viewState: CameraViewState = .loading
     public var isCameraViewStateCapturing: Bool { viewState.captureInProgress }
     var cameraLayout: DualCameraLayout
+    var contentMode: DualCameraContentMode
     var containerSize: CGSize = .zero
     var displayScale: CGFloat = 1
 
@@ -54,12 +55,14 @@ public final class DualCameraViewModel {
     public init(
         dualCameraController: DualCameraControlling? = nil,
         layout: DualCameraLayout = .piP(miniCamera: .front, miniCameraPosition: .bottomTrailing),
+        contentMode: DualCameraContentMode = .aspectFill,
         photoSaveStrategy: DualCameraPhotoSaveStrategy = .custom { _ in },
         showSettingsButton: Bool = false,
         showCameraFlashButton: Bool = true
     ) {
         self.controller = dualCameraController ?? CurrentDualCameraEnvironment.dualCameraController
         self.cameraLayout = layout
+        self.contentMode = contentMode
         self.photoSaveStrategy = photoSaveStrategy
         self.isSettingsButtonVisible = showSettingsButton
         self.showCameraFlashButton = showCameraFlashButton
@@ -122,7 +125,8 @@ public final class DualCameraViewModel {
             let image = try await controller.capturePhoto(
                 layout: cameraLayout,
                 outputSize: containerSize,
-                displayScale: displayScale
+                displayScale: displayScale,
+                contentMode: contentMode
             )
 
             capturedPhoto = image

--- a/Tests/DualCameraKitTests/DualCameraCameraStreamSourceTests.swift
+++ b/Tests/DualCameraKitTests/DualCameraCameraStreamSourceTests.swift
@@ -11,6 +11,7 @@ final class DualCameraCameraStreamSourceTests: XCTestCase {
 
         XCTAssertNotNil(source.latestFrame(for: .front))
         XCTAssertNotNil(source.latestFrame(for: .back))
+        XCTAssertNotNil(source.latestFramePair())
     }
 
     func test_mockStreamSourceReplaysLatestFrameToNewSubscriber() async throws {

--- a/Tests/DualCameraKitTests/DualCameraControllerTests.swift
+++ b/Tests/DualCameraKitTests/DualCameraControllerTests.swift
@@ -136,6 +136,7 @@ private final class RecordingPhotoCapturer: DualCameraPhotoCapturing {
         return (UIImage(), UIImage())
     }
 
+    // swiftlint:disable:next function_parameter_count
     func captureComposedPhoto(
         frontBuffer: CVPixelBuffer,
         backBuffer: CVPixelBuffer,

--- a/Tests/DualCameraKitTests/DualCameraControllerTests.swift
+++ b/Tests/DualCameraKitTests/DualCameraControllerTests.swift
@@ -1,5 +1,5 @@
 import AVFoundation
-import DualCameraKit
+@testable import DualCameraKit
 import XCTest
 
 @MainActor

--- a/Tests/DualCameraKitTests/DualCameraControllerTests.swift
+++ b/Tests/DualCameraKitTests/DualCameraControllerTests.swift
@@ -4,6 +4,26 @@ import XCTest
 
 @MainActor
 final class DualCameraControllerTests: XCTestCase {
+    func test_captureRawPhotosUsesSynchronizedFramePair() async throws {
+        let streamSource = SpyCameraStreamSource()
+        let expectedFront = try makePixelBuffer(color: .red)
+        let expectedBack = try makePixelBuffer(color: .blue)
+        streamSource.framePair = DualCameraFramePair(
+            front: PixelBufferWrapper(buffer: expectedFront),
+            back: PixelBufferWrapper(buffer: expectedBack)
+        )
+        let photoCapturer = RecordingPhotoCapturer()
+        let controller = DualCameraController(
+            photoCapturer: photoCapturer,
+            streamSource: streamSource
+        )
+
+        _ = try await controller.captureRawPhotos()
+
+        XCTAssertTrue(photoCapturer.rawFrontBuffer === expectedFront)
+        XCTAssertTrue(photoCapturer.rawBackBuffer === expectedBack)
+    }
+
     func test_stopSessionDebouncesDuringNavigationHandoff() async throws {
         let streamSource = SpyCameraStreamSource()
         let sleeper = ManualSessionStopSleeper()
@@ -91,6 +111,42 @@ final class DualCameraControllerTests: XCTestCase {
         XCTAssertEqual(streamSource.startCount, 2)
         XCTAssertEqual(streamSource.stopCount, 1)
     }
+
+    private func makePixelBuffer(color: UIColor) throws -> CVPixelBuffer {
+        guard let buffer = color.asImage(CGSize(width: 4, height: 4)).pixelBuffer() else {
+            throw DualCameraError.captureFailure(.imageCreationFailed)
+        }
+        return buffer
+    }
+}
+
+@MainActor
+private final class RecordingPhotoCapturer: DualCameraPhotoCapturing {
+    var rawFrontBuffer: CVPixelBuffer?
+    var rawBackBuffer: CVPixelBuffer?
+    var composedContentMode: DualCameraContentMode?
+
+    func captureRawPhotos(
+        frontBuffer: CVPixelBuffer,
+        backBuffer: CVPixelBuffer,
+        displayScale: CGFloat
+    ) async throws -> (front: UIImage, back: UIImage) {
+        rawFrontBuffer = frontBuffer
+        rawBackBuffer = backBuffer
+        return (UIImage(), UIImage())
+    }
+
+    func captureComposedPhoto(
+        frontBuffer: CVPixelBuffer,
+        backBuffer: CVPixelBuffer,
+        layout: DualCameraLayout,
+        outputSize: CGSize,
+        displayScale: CGFloat,
+        contentMode: DualCameraContentMode
+    ) async throws -> UIImage {
+        composedContentMode = contentMode
+        return UIImage()
+    }
 }
 
 @MainActor
@@ -137,6 +193,7 @@ private final class SpyCameraStreamSource: DualCameraCameraStreamSourcing {
     var stopCount = 0
     var startError: Error?
     var torchModes: [AVCaptureDevice.TorchMode] = []
+    nonisolated(unsafe) var framePair: DualCameraFramePair?
     private var stopWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
 
     func startSession() async throws {
@@ -170,9 +227,31 @@ private final class SpyCameraStreamSource: DualCameraCameraStreamSourcing {
         nil
     }
 
+    nonisolated func subscribeToFramePairs() -> AsyncStream<DualCameraFramePair> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    nonisolated func latestFramePair() -> DualCameraFramePair? {
+        framePair
+    }
+
+    nonisolated func diagnostics() -> DualCameraDiagnostics {
+        DualCameraDiagnostics()
+    }
+
     func setTorchMode(_ mode: AVCaptureDevice.TorchMode) throws {
         torchModes.append(mode)
     }
+
+    func setZoomFactor(_ factor: CGFloat, for source: DualCameraSource) throws {}
+
+    func setFocusMode(_ mode: AVCaptureDevice.FocusMode, for source: DualCameraSource) throws {}
+
+    func setExposureMode(_ mode: AVCaptureDevice.ExposureMode, for source: DualCameraSource) throws {}
+
+    func setWhiteBalanceMode(_ mode: AVCaptureDevice.WhiteBalanceMode, for source: DualCameraSource) throws {}
 
     private func resumeReadyStopWaiters() {
         let readyWaiters = stopWaiters.filter { stopCount >= $0.count }

--- a/Tests/DualCameraKitTests/DualCameraPhotoCapturerTests.swift
+++ b/Tests/DualCameraKitTests/DualCameraPhotoCapturerTests.swift
@@ -31,8 +31,47 @@ final class DualCameraPhotoCapturerTests: XCTestCase {
         XCTAssertTrue(try photos.back.isPixelNear(pixelX: 5, pixelY: 5, to: .blue))
     }
 
+    func test_composedPhotoAspectFillCropsToFillRegionByDefault() async throws {
+        let capturer = DualCameraPhotoCapturer()
+        let front = try makePixelBuffer(color: .red, size: CGSize(width: 20, height: 10))
+        let back = try makePixelBuffer(color: .blue, size: CGSize(width: 20, height: 10))
+
+        let image = try await capturer.captureComposedPhoto(
+            frontBuffer: front,
+            backBuffer: back,
+            layout: .sideBySide,
+            outputSize: CGSize(width: 20, height: 10)
+        )
+
+        XCTAssertTrue(try image.isPixelNear(pixelX: 15, pixelY: 1, to: .red))
+        XCTAssertTrue(try image.isPixelNear(pixelX: 15, pixelY: 8, to: .red))
+    }
+
+    func test_composedPhotoAspectFitLetterboxesRegion() async throws {
+        let capturer = DualCameraPhotoCapturer()
+        let front = try makePixelBuffer(color: .red, size: CGSize(width: 20, height: 10))
+        let back = try makePixelBuffer(color: .blue, size: CGSize(width: 20, height: 10))
+
+        let image = try await capturer.captureComposedPhoto(
+            frontBuffer: front,
+            backBuffer: back,
+            layout: .sideBySide,
+            outputSize: CGSize(width: 20, height: 10),
+            displayScale: 1,
+            contentMode: .aspectFit
+        )
+
+        XCTAssertTrue(try image.isPixelNear(pixelX: 15, pixelY: 1, to: .black))
+        XCTAssertTrue(try image.isPixelNear(pixelX: 15, pixelY: 5, to: .red))
+        XCTAssertTrue(try image.isPixelNear(pixelX: 15, pixelY: 8, to: .black))
+    }
+
     private func makePixelBuffer(color: UIColor) throws -> CVPixelBuffer {
-        guard let buffer = color.asImage(CGSize(width: 10, height: 10)).pixelBuffer() else {
+        try makePixelBuffer(color: color, size: CGSize(width: 10, height: 10))
+    }
+
+    private func makePixelBuffer(color: UIColor, size: CGSize) throws -> CVPixelBuffer {
+        guard let buffer = color.asImage(size).pixelBuffer() else {
             throw DualCameraError.captureFailure(.imageCreationFailed)
         }
         return buffer

--- a/Tests/DualCameraKitTests/DualCameraVideoOrientationProviderTests.swift
+++ b/Tests/DualCameraKitTests/DualCameraVideoOrientationProviderTests.swift
@@ -1,0 +1,19 @@
+import Testing
+import UIKit
+@testable import DualCameraKit
+
+@MainActor
+struct DualCameraVideoOrientationProviderTests {
+    @Test
+    func flatAndUnknownOrientationsPreserveLastValidRotationAngle() {
+        let provider = DeviceVideoOrientationProvider()
+
+        #expect(provider.videoRotationAngle(for: .landscapeRight) == 180)
+        #expect(provider.videoRotationAngle(for: .faceUp) == 180)
+        #expect(provider.videoRotationAngle(for: .faceDown) == 180)
+        #expect(provider.videoRotationAngle(for: .unknown) == 180)
+
+        #expect(provider.videoRotationAngle(for: .portraitUpsideDown) == 270)
+        #expect(provider.videoRotationAngle(for: .faceUp) == 270)
+    }
+}

--- a/Tests/DualCameraKitTests/DualCameraViewModelTests.swift
+++ b/Tests/DualCameraKitTests/DualCameraViewModelTests.swift
@@ -106,6 +106,7 @@ final class DualCameraViewModelTests: XCTestCase {
 
         XCTAssertEqual(controller.captureOutputSize, CGSize(width: 320, height: 480))
         XCTAssertEqual(controller.captureDisplayScale, 3)
+        XCTAssertEqual(controller.captureContentMode, .aspectFill)
         XCTAssertNotNil(viewModel.capturedPhoto)
         let savedCapturedImage = await savedImage.get()
         XCTAssertTrue(savedCapturedImage === controller.mockCapturedImage)
@@ -153,6 +154,7 @@ final class MockDualCameraController: DualCameraControlling {
     var torchModes: [AVCaptureDevice.TorchMode] = []
     var captureOutputSize: CGSize?
     var captureDisplayScale: CGFloat?
+    var captureContentMode: DualCameraContentMode?
     let mockCapturedImage = UIImage()
 
     func subscribe(to source: DualCameraSource) -> AsyncStream<PixelBufferWrapper> {
@@ -180,12 +182,18 @@ final class MockDualCameraController: DualCameraControlling {
         (mockCapturedImage, mockCapturedImage)
     }
 
-    func capturePhoto(layout: DualCameraLayout, outputSize: CGSize, displayScale: CGFloat) async throws -> UIImage {
+    func capturePhoto(
+        layout: DualCameraLayout,
+        outputSize: CGSize,
+        displayScale: CGFloat,
+        contentMode: DualCameraContentMode
+    ) async throws -> UIImage {
         if shouldFailCapturePhoto {
             throw DualCameraError.captureFailure(.noFrameAvailable)
         }
         captureOutputSize = outputSize
         captureDisplayScale = displayScale
+        captureContentMode = contentMode
         return mockCapturedImage
     }
 
@@ -195,11 +203,24 @@ final class MockDualCameraController: DualCameraControlling {
         }
         torchModes.append(mode)
     }
+
+    func setZoomFactor(_ factor: CGFloat, for source: DualCameraSource) throws {}
+
+    func setFocusMode(_ mode: AVCaptureDevice.FocusMode, for source: DualCameraSource) throws {}
+
+    func setExposureMode(_ mode: AVCaptureDevice.ExposureMode, for source: DualCameraSource) throws {}
+
+    func setWhiteBalanceMode(_ mode: AVCaptureDevice.WhiteBalanceMode, for source: DualCameraSource) throws {}
+
+    func diagnostics() -> DualCameraDiagnostics {
+        DualCameraDiagnostics()
+    }
 }
 
 @MainActor
 final class MockCameraRenderer: CameraRenderer {
     let view = UIView()
+    var cameraContentMode: DualCameraContentMode = .aspectFill
 
-    func update(with buffer: CVPixelBuffer) {}
+    nonisolated func update(with frame: PixelBufferWrapper) {}
 }

--- a/Tests/DualCameraKitTests/MediaSaveStrategyTests.swift
+++ b/Tests/DualCameraKitTests/MediaSaveStrategyTests.swift
@@ -31,7 +31,7 @@ final class MediaSaveStrategyTests: XCTestCase {
 
     func test_mediaLibraryStrategy_unimplementedFails() async {
         let strategy = DualCameraPhotoSaveStrategy.saveToMediaLibrary(MediaLibraryService.failing.saveImage)
-        await XCTAssertThrowsError(ofType: MediaLibraryError.self, try await strategy.save(UIImage()) )
+        await XCTAssertThrowsError(ofType: MediaLibraryError.self, try await strategy.save(UIImage()))
     }
 
 }

--- a/Tests/Helpers/XCTAssertThrowsError.swift
+++ b/Tests/Helpers/XCTAssertThrowsError.swift
@@ -4,7 +4,7 @@ import XCTest
 public func XCTAssertThrowsError<T: Error>(
     ofType expectedType: T.Type,
     _ expression: @autoclosure () async throws -> Void,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) async -> T? {
     do {


### PR DESCRIPTION
## Summary
- Move `Package.swift` to Swift 6 language mode and remove unsafe SwiftPM flags.
- Add `DualCameraContentMode` with `.aspectFill` as the default and `.aspectFit` support for preview and composed capture.
- Capture synchronized front/back frame pairs using `AVCaptureDataOutputSynchronizer`.
- Retain source `CMSampleBuffer`s through `PixelBufferWrapper` so pixel buffer lifetime is owned while frames are in use.
- Update Metal rendering to use a thread-safe latest-frame store and continuous display-link rendering.
- Move layout menu/title presentation strings out of `DualCameraKit` and into `DualCameraKitUI`.
- Add orientation-provider injection, diagnostics counters, and per-camera control hooks.
- Deprecate the process-wide mutable environment global without removing it.

## Validation
- `git diff --check`
- `xcodebuild -project DualCameraDemo/DualCameraDemo.xcodeproj -scheme DualCameraDemo -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' test -only-testing:DualCameraDemoTests`
